### PR TITLE
ci: setup release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          changelog: CHANGELOG.md
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
+    needs: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: vrcwatch-rs
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.0](https://github.com/Quesys-tech/vrcwatch.rs/releases/tag/v0.1.0) - 2025-03-09
+
 ### Added
+
 - Sending OSC parameter for analogue watches (`DateTimeSecondFA`, `DateTimeMinuteFA`, `DateTimeHourFA`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "vrcwatch-rs"
 version = "0.1.0"
 edition = "2021"
+publish = false
+license = "MIT"
+description = "A VRChat watch driver via OSC"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
ojbective: release
content: 
- changelog
- license, description and publish settings in `Cargo.toml`
- release workflow: https://github.com/taiki-e/upload-rust-binary-action