### PR TITLE
ci: use Swatinem/rust-cache to cache dependencies

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      - run: rustup toolchain install stable --profile minimal --no-self-update
+      - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build --verbose
       - name: Run tests


### PR DESCRIPTION
- CIのビルドが遅い
-  Swatinem/rust-cache で依存関係をキャッシュ