### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-  
+
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -19,4 +22,3 @@ jobs:
         run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
-  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### 🐛 Bug Fixes
+
+- *(ci)* Potential fix for code scanning alert no. 1: Workflow does not contain permissions
+
 ## [0.4.0] - 2025-06-13
 
 ### 🚀 Features


### PR DESCRIPTION
Potential fix for [https://github.com/Quesys-tech/vrcwatch.rs/security/code-scanning/1](https://github.com/Quesys-tech/vrcwatch.rs/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily interacts with the repository's contents (e.g., checking out code), the `contents: read` permission is sufficient. This change should be applied at the root of the workflow to cover all jobs unless specific jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
